### PR TITLE
#85 Обновить зависимости и ридми в соответствии с node 12

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
-DB_NAME=interview
+DB_TYPE=postgres
+DB_HOST=localhost
 DB_PORT=15023
+DB_NAME=interview
 DB_PASSWORD=test
 DB_USER=test
 DB_LOGGING=false

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
 test:
 	npm run test
 
-setup:
+setup: create_development_vars fixtures-load
+
+create_development_vars:
 	cp -n .env.example development.env || true
-	npm run fixtures:load
 
 install:
-	npm install
+	npm ci
 
 start:
 	npm run start:dev

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 * Обсуждение в канале #nodejs слака http://slack-ru.hexlet.io
 
 ### Requirements
-* NodeJS >= 10.16.0
-* npm >= 6
+* NodeJS >= 12.13.0
+* npm >= 6.12
 * docker & docker-compose
 
 ### Run

--- a/src/modules/config/config.service.ts
+++ b/src/modules/config/config.service.ts
@@ -1,6 +1,7 @@
 import dotenv from 'dotenv';
 import { TypeOrmModuleOptions } from '@nestjs/typeorm';
 import { join } from 'path';
+import { ConnectionOptions, DatabaseType } from 'typeorm';
 
 export interface MailParams {
   driver: string;
@@ -63,24 +64,24 @@ export class ConfigService {
     };
 
     const test: TypeOrmModuleOptions = {
-      type: 'postgres',
-      host: 'localhost',
+      type: process.env.DB_TYPE as DatabaseType,
+      host: process.env.DB_HOST,
       port: Number(process.env.DB_PORT),
       username: process.env.DB_USER,
       password: process.env.DB_PASSWORD,
       database: process.env.DB_NAME,
       ...commonOptions,
-    };
+    } as ConnectionOptions;
 
     const development: TypeOrmModuleOptions = {
-      type: 'postgres',
-      host: 'localhost',
+      type: process.env.DB_TYPE as DatabaseType,
+      host: process.env.DB_HOST,
       port: Number(process.env.DB_PORT),
       username: process.env.DB_USER,
       password: process.env.DB_PASSWORD,
       database: process.env.DB_NAME,
       ...commonOptions,
-    };
+    } as ConnectionOptions;
 
     const production: TypeOrmModuleOptions = {
       type: 'postgres',

--- a/test.env
+++ b/test.env
@@ -1,5 +1,7 @@
-DB_NAME=interview-test
+DB_TYPE=postgres
+DB_HOST=localhost
 DB_PORT=15025
+DB_NAME=interview-test
 DB_PASSWORD=test
 DB_USER=test
 


### PR DESCRIPTION
Зависимости под 12й нодой запустились без конфликтов и deprectated. Обновлены требования в Readme + вынесено в переменные окружения полное конфигурирование БД + заменён `npm install` на `npm ci` для установки зависимостей из lock-файла

Closes #85